### PR TITLE
remove crazy ass pydantic version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = [{ from = "src", include = "iterative" }]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pydantic = "^2.6.4"
+pydantic = "^1.8.2"
 inflect = "^7.0.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Downgraded Pydantic version to 1.8.2 for better compatibility with existing codebase and dependencies.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Downgrade Pydantic Version for Compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pyproject.toml

- Downgraded Pydantic version from 2.6.4 to 1.8.2.



</details>
    

  </td>
  <td><a href="https://github.com/colorfull-ai/iterative/pull/6/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

